### PR TITLE
Fix warning to vararg type

### DIFF
--- a/garum/src/main/java/com/os/operando/garum/Configuration.java
+++ b/garum/src/main/java/com/os/operando/garum/Configuration.java
@@ -50,12 +50,14 @@ public class Configuration {
             return this;
         }
 
-        public Builder addModelClasses(Class<? extends PrefModel>... modelClasses) {
+        @SafeVarargs
+        public final Builder addModelClasses(Class<? extends PrefModel>... modelClasses) {
             this.modelClasses.addAll(Arrays.asList(modelClasses));
             return this;
         }
 
-        public Builder setModelClasses(Class<? extends PrefModel>... modelClasses) {
+        @SafeVarargs
+        public final Builder setModelClasses(Class<? extends PrefModel>... modelClasses) {
             this.modelClasses = Arrays.asList(modelClasses);
             return this;
         }

--- a/garum/src/main/java/com/os/operando/garum/Configuration.java
+++ b/garum/src/main/java/com/os/operando/garum/Configuration.java
@@ -70,7 +70,8 @@ public class Configuration {
             return this;
         }
 
-        public Builder addTypeSerializers(Class<? extends TypeSerializer>... typeSerializers) {
+        @SafeVarargs
+        public final Builder addTypeSerializers(Class<? extends TypeSerializer>... typeSerializers) {
             if (this.typeSerializers == null) {
                 this.typeSerializers = new ArrayList<>();
             }
@@ -78,7 +79,8 @@ public class Configuration {
             return this;
         }
 
-        public Builder setTypeSerializers(Class<? extends TypeSerializer>... typeSerializers) {
+        @SafeVarargs
+        public final Builder setTypeSerializers(Class<? extends TypeSerializer>... typeSerializers) {
             this.typeSerializers = Arrays.asList(typeSerializers);
             return this;
         }


### PR DESCRIPTION
In the following method does not perform potentially unsafe operations on its varargs parameter. 

* `Configuration.Builder.addModelClasses()`
* `Configuration.Builder.setModelClasses()`
* `Configuration.Builder.addTypeSerializers()`
* `Configuration.Builder.setTypeSerializers()`

So, Added `@SafeVarargs` annotation to those methods.

https://docs.oracle.com/javase/7/docs/api/java/lang/SafeVarargs.html

## issue

https://github.com/operando/Garum/issues/11